### PR TITLE
Add CommandLine and BrowserProcessType WinDBG extensions

### DIFF
--- a/.github/instructions/native_extension.instructions.md
+++ b/.github/instructions/native_extension.instructions.md
@@ -19,19 +19,3 @@ applyTo: "**/*.cpp,**/*.h"
 - When creating a new command that is exported from the extension, ensure that it has help text that is printed out to the command window when the user passes "?" as the first argument to the command.
 - Put the extern methods at the end of the file wrapped in a `extern "C" {}` block.
 
-## Use the following extra files for context
-
-[dbgeng.h](dbgeng.h)
-[utils.h](../../src/utils.h)
-[utils.cpp](../../src/utils.cpp)
-[breakpoints_history.cpp](../../src/breakpoints_history.cpp)
-[breakpoint_list.cpp](../../src/breakpoint_list.cpp)
-[breakpoint_list.h](../../src/breakpoint_list.h)
-[break_commands.cpp](../../src/break_commands.cpp)
-[command_list.cpp](../../src/command_list.cpp)
-[command_list.h](../../src/command_list.h)
-[command_lists.cpp](../../src/command_lists.cpp)
-[command_logger.cpp](../../src/command_logger.cpp)
-[js_command_wrappers.cpp](../../src/js_command_wrappers.cpp)
-[CMakeLists.txt](../../CMakeLists.txt)
-[GenerateStartupCommands.cmake](../../cmake/GenerateStartupCommands.cmake)

--- a/.github/instructions/native_extension.instructions.md
+++ b/.github/instructions/native_extension.instructions.md
@@ -19,3 +19,11 @@ applyTo: "**/*.cpp,**/*.h"
 - When creating a new command that is exported from the extension, ensure that it has help text that is printed out to the command window when the user passes "?" as the first argument to the command.
 - Put the extern methods at the end of the file wrapped in a `extern "C" {}` block.
 
+## The following files should be used as references for writing new extensions (but not for what those extensions do):
+
+[dbgeng.h](dbgeng.h)
+[utils.h](../../src/utils.h)
+[utils.cpp](../../src/utils.cpp)
+[js_command_wrappers.cpp](../../src/js_command_wrappers.cpp)
+[CMakeLists.txt](../../CMakeLists.txt)
+[GenerateStartupCommands.cmake](../../cmake/GenerateStartupCommands.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ endfunction()
 # Native extensions
 add_windbg_extension(break_commands src/break_commands.cpp)
 add_windbg_extension(breakpoints_history src/breakpoints_history.cpp src/breakpoint_list.cpp src/breakpoint.cpp)
+add_windbg_extension(browser_process_manager src/browser_process_manager.cpp)
 add_windbg_extension(command_lists src/command_lists.cpp src/command_list.cpp)
 add_windbg_extension(command_logger src/command_logger.cpp)
 add_windbg_extension(js_command_wrappers src/js_command_wrappers.cpp)
@@ -65,6 +66,7 @@ add_custom_target(generate_startup_commands ALL
     DEPENDS
         break_commands
         breakpoints_history
+        browser_process_manager
         command_lists
         command_logger
         js_command_wrappers

--- a/build.ps1
+++ b/build.ps1
@@ -8,6 +8,59 @@ param(
     [string]$TestName = ""
 )
 
+# Set up Visual Studio Developer Environment
+function Initialize-VsDevEnvironment {
+    # Common Visual Studio installation paths
+    $vsPaths = @(
+        "${env:ProgramFiles}\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1",
+        "${env:ProgramFiles}\Microsoft Visual Studio\2022\Professional\Common7\Tools\Launch-VsDevShell.ps1",
+        "${env:ProgramFiles}\Microsoft Visual Studio\2022\Community\Common7\Tools\Launch-VsDevShell.ps1",
+        "${env:ProgramFiles}\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\Launch-VsDevShell.ps1",
+        "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\Launch-VsDevShell.ps1",
+        "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Professional\Common7\Tools\Launch-VsDevShell.ps1",
+        "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Community\Common7\Tools\Launch-VsDevShell.ps1",
+        "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\Launch-VsDevShell.ps1"
+    )
+
+    # Check if we're already in a VS Developer environment
+    if ($env:VSINSTALLDIR) {
+        Write-Host "Already in Visual Studio Developer environment." -ForegroundColor Green
+        return
+    }
+
+    # Find and execute the VS Developer shell script
+    foreach ($path in $vsPaths) {
+        if (Test-Path $path) {
+            Write-Host "Setting up Visual Studio Developer environment..." -ForegroundColor Cyan
+            & $path -Arch amd64 -HostArch amd64
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host "Visual Studio Developer environment initialized." -ForegroundColor Green
+                return
+            }
+        }
+    }
+
+    Write-Host "Warning: Could not find Visual Studio Developer environment." -ForegroundColor Yellow
+    Write-Host "Please ensure Visual Studio 2019/2022 with C++ tools is installed." -ForegroundColor Yellow
+}
+
+# Initialize VS Developer environment
+Initialize-VsDevEnvironment
+
+# Ensure we're in the correct directory (where this script is located)
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+if ($PWD.Path -ne $scriptDir) {
+    Write-Host "Changing to script directory: $scriptDir" -ForegroundColor Cyan
+    Set-Location $scriptDir
+}
+
+# Verify CMakeLists.txt exists
+if (-not (Test-Path "CMakeLists.txt")) {
+    Write-Host "Error: CMakeLists.txt not found in current directory." -ForegroundColor Red
+    Write-Host "Please ensure you're running this script from the WinDbg extensions project root." -ForegroundColor Red
+    exit 1
+}
+
 # Create build directory
 $buildDir = "build"
 if ($Action -eq "clean") {

--- a/cmake/GenerateStartupCommands.cmake
+++ b/cmake/GenerateStartupCommands.cmake
@@ -29,6 +29,7 @@ set(POST_LOAD_COMMANDS
     "as #gcl !GetCallbackLocation"
     "as #stm !StepThroughMojo"
     "as #cl  !CommandLine"
+    "as #bpt !BrowserProcessType"
 
     "!EnableStepThroughMojo"
     "!AddBreakCommand !ShowNearbyCommandLists"

--- a/cmake/GenerateStartupCommands.cmake
+++ b/cmake/GenerateStartupCommands.cmake
@@ -3,6 +3,7 @@
 set(EXTENSIONS
     break_commands
     breakpoints_history
+    browser_process_manager
     command_lists
     command_logger
     js_command_wrappers
@@ -27,6 +28,7 @@ set(POST_LOAD_COMMANDS
     "as #sif !StepIntoFunction"
     "as #gcl !GetCallbackLocation"
     "as #stm !StepThroughMojo"
+    "as #cl  !CommandLine"
 
     "!EnableStepThroughMojo"
     "!AddBreakCommand !ShowNearbyCommandLists"

--- a/src/browser_process_manager.cpp
+++ b/src/browser_process_manager.cpp
@@ -5,10 +5,15 @@
 #include <windows.h>
 #include <string>
 #include <vector>
+#include <algorithm>
 
 #include "utils.h"
 
 utils::DebugInterfaces g_debug;
+
+// Forward declarations
+std::string GetProcessCommandLine();
+std::string ClassifyBrowserProcessType(const std::string& command_line);
 
 HRESULT CALLBACK DebugExtensionInitializeInternal(PULONG version,
                                                   PULONG flags) {
@@ -31,46 +36,174 @@ HRESULT CALLBACK CommandLineInternal(IDebugClient* client, const char* args) {
     return S_OK;
   }
 
+  std::string command_line = GetProcessCommandLine();
+
+  if (command_line.empty()) {
+      DOUT("Error: Failed to get command line information.\n");
+      DOUT("This could indicate that no process is being debugged, the debugger is not attached properly,\n");
+      DOUT("or the PEB format is different than expected.\n");
+      return E_FAIL;
+  }
+
+  DOUT("%s\n", command_line.c_str());
+  return S_OK;
+}
+
+std::string GetProcessCommandLine() {
   try {
     // Get the Process Environment Block (PEB) to access command line
     std::string peb_command = "!peb";
     std::string peb_output = utils::ExecuteCommand(&g_debug, peb_command);
     
     if (peb_output.empty()) {
-      DOUT("Error: Failed to get PEB information.\n");
-      return E_FAIL;
+      return "";
     }
     
     // Look for CommandLine in the PEB output
     size_t cmd_line_pos = peb_output.find("CommandLine:");
     if (cmd_line_pos == std::string::npos) {
-      DOUT("Error: Could not find CommandLine in PEB output.\n");
-      return E_FAIL;
+      return "";
     }
     
     // Extract the command line portion
     size_t start_pos = peb_output.find("'", cmd_line_pos);
     if (start_pos == std::string::npos) {
-      DOUT("Error: Could not parse CommandLine from PEB output.\n");
-      return E_FAIL;
+      return "";
     }
     start_pos++; // Skip the opening quote
     
     size_t end_pos = peb_output.find("'", start_pos);
     if (end_pos == std::string::npos) {
-      DOUT("Error: Could not find end of CommandLine in PEB output.\n");
+      return "";
+    }
+    
+    return peb_output.substr(start_pos, end_pos - start_pos);
+    
+  } catch (...) {
+    return "";
+  }
+}
+
+std::string ClassifyBrowserProcessType(const std::string& command_line) {
+  if (command_line.empty()) {
+    return "Unknown";
+  }
+  
+  // Convert to lowercase for case-insensitive matching
+  std::string cmd_lower = command_line;
+  std::transform(cmd_lower.begin(), cmd_lower.end(), cmd_lower.begin(), ::tolower);
+  
+  // Check for specific process types based on command line arguments
+  if (cmd_lower.find("--type=renderer") != std::string::npos) {
+    return "Renderer";
+  }
+  else if (cmd_lower.find("--type=gpu-process") != std::string::npos) {
+    return "GPU";
+  }
+  else if (cmd_lower.find("--type=utility") != std::string::npos) {
+    // Check for specific utility process subtypes
+    if (cmd_lower.find("--utility-sub-type=network.mojom.networkservice") != std::string::npos ||
+        cmd_lower.find("network.mojom.networkservice") != std::string::npos) {
+      return "Utility:Network";
+    }
+    else if (cmd_lower.find("--utility-sub-type=audio.mojom.audioservice") != std::string::npos ||
+             cmd_lower.find("audio.mojom.audioservice") != std::string::npos) {
+      return "Utility:Audio";
+    }
+    else if (cmd_lower.find("--utility-sub-type=storage.mojom.storageservice") != std::string::npos ||
+             cmd_lower.find("storage.mojom.storageservice") != std::string::npos) {
+      return "Utility:Storage";
+    }
+    else if (cmd_lower.find("--utility-sub-type=video_capture.mojom.videocaptureservice") != std::string::npos ||
+             cmd_lower.find("video_capture.mojom.videocaptureservice") != std::string::npos) {
+      return "Utility:VideoCapture";
+    }
+    else {
+      // Try to extract the utility sub-type
+      size_t sub_type_pos = cmd_lower.find("--utility-sub-type=");
+      if (sub_type_pos != std::string::npos) {
+        size_t sub_type_start = sub_type_pos + 19; // Length of "--utility-sub-type="
+        size_t sub_type_end = cmd_lower.find(" ", sub_type_start);
+        if (sub_type_end == std::string::npos) {
+          sub_type_end = cmd_lower.length();
+        }
+        std::string sub_type = cmd_lower.substr(sub_type_start, sub_type_end - sub_type_start);
+        return "Utility:" + sub_type;
+      }
+      return "Utility:Other";
+    }
+  }
+  else if (cmd_lower.find("--type=ppapi") != std::string::npos) {
+    return "PPAPI";
+  }
+  else if (cmd_lower.find("--type=crashpad-handler") != std::string::npos) {
+    return "CrashHandler";
+  }
+  else if (cmd_lower.find("--type=zygote") != std::string::npos) {
+    return "Zygote";
+  }
+  else if (cmd_lower.find("--type=sandbox-helper") != std::string::npos) {
+    return "SandboxHelper";
+  }
+  else if (cmd_lower.find("--type=") != std::string::npos) {
+    // Extract the process type if it's something we don't recognize
+    size_t type_pos = cmd_lower.find("--type=");
+    size_t type_start = type_pos + 7; // Length of "--type="
+    size_t type_end = cmd_lower.find(" ", type_start);
+    if (type_end == std::string::npos) {
+      type_end = cmd_lower.length();
+    }
+    std::string process_type = cmd_lower.substr(type_start, type_end - type_start);
+    return "Unknown:" + process_type;
+  }
+  else {
+    // No --type argument, likely the main browser process
+    return "Browser";
+  }
+}
+
+HRESULT CALLBACK BrowserProcessTypeInternal(IDebugClient* client, const char* args) {
+  if (args && *args && (args[0] == '?' && args[1] == '\0')) {
+    DOUT(
+        "BrowserProcessType - Classifies the type of browser process.\n\n"
+        "Usage: !BrowserProcessType\n"
+        "Alias: !#bpt\n\n"
+        "This command analyzes the command line of the current process\n"
+        "and classifies it as one of the following browser process types:\n\n"
+        "  Browser          - Main browser process\n"
+        "  Renderer         - Web content renderer process\n"
+        "  GPU              - GPU process\n"
+        "  Utility:Network  - Network service utility process\n"
+        "  Utility:Audio    - Audio service utility process\n"
+        "  Utility:Storage  - Storage service utility process\n"
+        "  Utility:VideoCapture - Video capture utility process\n"
+        "  Utility:Other    - Other utility process\n"
+        "  PPAPI            - PPAPI plugin process\n"
+        "  CrashHandler     - Crashpad handler process\n"
+        "  Zygote           - Zygote process (Linux)\n"
+        "  SandboxHelper    - Sandbox helper process\n"
+        "  Unknown:<type>   - Unrecognized process type\n"
+        "  Unknown          - Could not determine process type\n");
+    return S_OK;
+  }
+
+  try {
+    std::string command_line = GetProcessCommandLine();
+    
+    if (command_line.empty()) {
+      DOUT("Error: Could not retrieve command line for process classification.\n");
       return E_FAIL;
     }
     
-    std::string command_line = peb_output.substr(start_pos, end_pos - start_pos);
+    std::string process_type = ClassifyBrowserProcessType(command_line);
     
-    DOUT("Command Line: %s\n", command_line.c_str());
+    DOUT("%s\n", process_type.c_str());
     
   } catch (const std::exception& e) {
-    DOUT("Error retrieving command line: %s\n", e.what());
+    DOUT("Error classifying browser process type: %s\n", e.what());
     return E_FAIL;
   } catch (...) {
-    DOUT("Unknown error retrieving command line.\n");
+    DOUT("Unknown error classifying browser process type.\n");
     return E_FAIL;
   }
   
@@ -89,6 +222,10 @@ __declspec(dllexport) HRESULT CALLBACK DebugExtensionUninitialize() {
 
 __declspec(dllexport) HRESULT CALLBACK CommandLine(IDebugClient* client, const char* args) {
   return CommandLineInternal(client, args);
+}
+
+__declspec(dllexport) HRESULT CALLBACK BrowserProcessType(IDebugClient* client, const char* args) {
+  return BrowserProcessTypeInternal(client, args);
 }
 
 }  // extern "C"

--- a/src/browser_process_manager.cpp
+++ b/src/browser_process_manager.cpp
@@ -22,18 +22,58 @@ HRESULT CALLBACK DebugExtensionUninitializeInternal() {
 }
 
 HRESULT CALLBACK CommandLineInternal(IDebugClient* client, const char* args) {
-  if (!args || !*args || (args[0] == '?' && args[1] == '\0')) {
+  if (args && *args && (args[0] == '?' && args[1] == '\0')) {
     DOUT(
-        "CommandLine - Manages browser process command line operations.\n\n"
-        "Usage: !CommandLine <operation> [parameters]\n\n"
-        "  <operation>  - Operation to perform (not yet implemented)\n"
-        "  [parameters] - Optional parameters for the operation\n\n"
-        "Note: This command is not yet implemented.\n");
+        "CommandLine - Gets the command line of the current process.\n\n"
+        "Usage: !CommandLine\n\n"
+        "This command displays the command line arguments used to start\n"
+        "the current process being debugged.\n");
     return S_OK;
   }
 
-  // TODO: Implement command line functionality
-  DOUT("CommandLine command is not yet implemented.\n");
+  try {
+    // Get the Process Environment Block (PEB) to access command line
+    std::string peb_command = "!peb";
+    std::string peb_output = utils::ExecuteCommand(&g_debug, peb_command);
+    
+    if (peb_output.empty()) {
+      DOUT("Error: Failed to get PEB information.\n");
+      return E_FAIL;
+    }
+    
+    // Look for CommandLine in the PEB output
+    size_t cmd_line_pos = peb_output.find("CommandLine:");
+    if (cmd_line_pos == std::string::npos) {
+      DOUT("Error: Could not find CommandLine in PEB output.\n");
+      return E_FAIL;
+    }
+    
+    // Extract the command line portion
+    size_t start_pos = peb_output.find("'", cmd_line_pos);
+    if (start_pos == std::string::npos) {
+      DOUT("Error: Could not parse CommandLine from PEB output.\n");
+      return E_FAIL;
+    }
+    start_pos++; // Skip the opening quote
+    
+    size_t end_pos = peb_output.find("'", start_pos);
+    if (end_pos == std::string::npos) {
+      DOUT("Error: Could not find end of CommandLine in PEB output.\n");
+      return E_FAIL;
+    }
+    
+    std::string command_line = peb_output.substr(start_pos, end_pos - start_pos);
+    
+    DOUT("Command Line: %s\n", command_line.c_str());
+    
+  } catch (const std::exception& e) {
+    DOUT("Error retrieving command line: %s\n", e.what());
+    return E_FAIL;
+  } catch (...) {
+    DOUT("Unknown error retrieving command line.\n");
+    return E_FAIL;
+  }
+  
   return S_OK;
 }
 

--- a/src/browser_process_manager.cpp
+++ b/src/browser_process_manager.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2025 Piet Hein Schouten
+// SPDX-License-Identifier: MIT
+
+#include <dbgeng.h>
+#include <windows.h>
+#include <string>
+#include <vector>
+
+#include "utils.h"
+
+utils::DebugInterfaces g_debug;
+
+HRESULT CALLBACK DebugExtensionInitializeInternal(PULONG version,
+                                                  PULONG flags) {
+  *version = DEBUG_EXTENSION_VERSION(1, 0);
+  *flags = 0;
+  return utils::InitializeDebugInterfaces(&g_debug);
+}
+
+HRESULT CALLBACK DebugExtensionUninitializeInternal() {
+  return utils::UninitializeDebugInterfaces(&g_debug);
+}
+
+HRESULT CALLBACK CommandLineInternal(IDebugClient* client, const char* args) {
+  if (!args || !*args || (args[0] == '?' && args[1] == '\0')) {
+    DOUT(
+        "CommandLine - Manages browser process command line operations.\n\n"
+        "Usage: !CommandLine <operation> [parameters]\n\n"
+        "  <operation>  - Operation to perform (not yet implemented)\n"
+        "  [parameters] - Optional parameters for the operation\n\n"
+        "Note: This command is not yet implemented.\n");
+    return S_OK;
+  }
+
+  // TODO: Implement command line functionality
+  DOUT("CommandLine command is not yet implemented.\n");
+  return S_OK;
+}
+
+extern "C" {
+
+__declspec(dllexport) HRESULT CALLBACK DebugExtensionInitialize(PULONG version, PULONG flags) {
+  return DebugExtensionInitializeInternal(version, flags);
+}
+
+__declspec(dllexport) HRESULT CALLBACK DebugExtensionUninitialize() {
+  return DebugExtensionUninitializeInternal();
+}
+
+__declspec(dllexport) HRESULT CALLBACK CommandLine(IDebugClient* client, const char* args) {
+  return CommandLineInternal(client, args);
+}
+
+}  // extern "C"


### PR DESCRIPTION
This change adds native WinDBG extension functionality to make working with Chromium/Edge processes easier.

!CommandLine / #cl
This will output just the current command line, without having to scroll and parse the !peb output manually.

!BrowserProcessType / #bpt
This command will output a simplified string of what kind of browser process or subprocess is the current process being debugged. For example, "Browser", "Renderer", "GPU", "Utility:Network", etc.

Additionally this change adds VS initialization to the build process so that it's now a single easy step for folks to build.